### PR TITLE
Release v0.6.0: CLI & from_seconds API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.6.0] - 2026-06-07
+
+### Added
+
+- CLI: `hmscalc add`, `sub`, `sum` (and `python -m hmscalc`)
+- `from_seconds()` raises `TypeError` for non-int input
+- Zenn tutorial draft (`docs/articles/work-time-tutorial.md`)
+- CLI subprocess tests
+
+### Changed
+
+- README: CLI section and input-path guidance (string vs seconds vs timedelta)
+
 ## [0.5.0] - 2026-06-07
 
 ### Added
@@ -85,6 +98,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Negative duration support
 - Custom exceptions: `InvalidTimeFormatError`, `NotTimeStringError`
 
+[0.6.0]: https://github.com/masanori0209/hmscalc/compare/v0.5.0...v0.6.0
 [0.5.0]: https://github.com/masanori0209/hmscalc/compare/v0.4.0...v0.5.0
 [0.4.0]: https://github.com/masanori0209/hmscalc/compare/v0.3.1...v0.4.0
 [0.3.1]: https://github.com/masanori0209/hmscalc/compare/v0.3.0...v0.3.1

--- a/README.md
+++ b/README.md
@@ -43,6 +43,24 @@ print(a / 2)   # "0:45:07"
 - Input whitespace trimming (`" 1:30:15 "`)
 - Type hints with `py.typed` marker
 - Python **3.9** through **3.14**
+- CLI: `hmscalc add` / `sub` / `sum` from the terminal
+
+## CLI
+
+After `pip install hmscalc`:
+
+```bash
+hmscalc add 1:30 2:15 0:45
+# 4:30:00
+
+hmscalc sub 2:00 0:45
+# 1:15:00
+
+hmscalc sum 1:00 2:00 3:00
+# 6:00:00
+```
+
+Equivalent: `python -m hmscalc add 1:00 2:00`
 
 ## Usage
 
@@ -51,6 +69,16 @@ print(a / 2)   # "0:45:07"
 ```python
 from hmscalc import HMSTime
 ```
+
+### Creating HMSTime (string vs seconds vs timedelta)
+
+| Input | Recommended API | Example |
+|-------|-----------------|---------|
+| `"1:30:15"` string | `HMSTime("1:30:15")` | Human-readable durations |
+| Integer seconds | `HMSTime.from_seconds(3661)` | Programmatic / computed values |
+| `datetime.timedelta` | `HMSTime.from_timedelta(delta)` | Interop with stdlib datetime |
+
+`HMSTime(...)` accepts **strings only**. Use `from_seconds()` for numeric seconds (`TypeError` if not `int`).
 
 ### Basic Operations
 
@@ -203,6 +231,7 @@ Docker matrix (Python 3.9–3.14): `docker build -t hmscalc . && docker run --rm
 - [Changelog](CHANGELOG.md)
 - [Contributing](CONTRIBUTING.md)
 - [Roadmap (v1.0.0)](https://github.com/masanori0209/hmscalc/issues/20)
+- [Zenn: 作業時間を HH:MM で足し算する（チュートリアル）](docs/articles/work-time-tutorial.md) — 公開用下書き
 - [Zenn: PyPI 公開の記事](https://zenn.dev/m2lab/articles/454a3a0dd27dc8)
 
 ## License

--- a/docs/articles/work-time-tutorial.md
+++ b/docs/articles/work-time-tutorial.md
@@ -1,0 +1,77 @@
+---
+title: "Python で作業時間を HH:MM 形式で足し算する"
+emoji: "⏱️"
+type: "tech"
+topics: ["python", "pypi", "timedelta", "hmscalc"]
+published: false
+---
+
+## はじめに
+
+作業ログや学習時間を `"2:15:30"` のような文字列で持っているとき、`datetime.timedelta` だけではパースから演算まで一手間かかります。  
+[hmscalc](https://pypi.org/project/hmscalc/) は **HH:MM / HH:MM:SS 文字列の加減算と集計** に特化した軽量ライブラリです。
+
+```bash
+pip install hmscalc
+```
+
+## ライブラリで集計する
+
+```python
+from hmscalc import HMSTime
+
+sessions = [
+    HMSTime("2:15:30"),
+    HMSTime("1:45:00"),
+    HMSTime("0:30:15"),
+]
+
+print(HMSTime.sum(sessions))  # 4:30:45
+```
+
+### 入力の使い分け
+
+| データ | API |
+|--------|-----|
+| 文字列 `"1:30:00"` | `HMSTime("1:30:00")` |
+| 秒数 `5400` | `HMSTime.from_seconds(5400)` |
+| `timedelta` | `HMSTime.from_timedelta(delta)` |
+
+## ターミナルから使う（CLI）
+
+```bash
+hmscalc add 1:30 2:15 0:45
+# 4:30:00
+
+hmscalc sub 5:00 1:30
+# 3:30:00
+```
+
+シェルスクリプトや CI ログの集計にもそのまま使えます。
+
+## timedelta との比較
+
+| | hmscalc | timedelta |
+|--|---------|-----------|
+| `"1:30:15"` を直接パース | ✅ | ❌（別途変換） |
+| 文字列での表示 | `"1:30:15"` | `1:30:15`（repr 依存） |
+| 24時間超の duration | ✅ | ✅ |
+| 標準ライブラリ | ❌ | ✅ |
+
+hmscalc は **人間が読む時刻文字列** を扱う層、timedelta は **日時計算の基盤** として併用するのがおすすめです。
+
+```python
+delta = HMSTime("1:30:00").to_timedelta()
+restored = HMSTime.from_timedelta(delta)
+```
+
+## まとめ
+
+- 作業時間の足し算・引き算 → `HMSTime` + `sum` / 演算子
+- コマンド一発 → `hmscalc add` / `sub` / `sum`
+- PyPI: https://pypi.org/project/hmscalc/
+- GitHub: https://github.com/masanori0209/hmscalc
+
+---
+
+> **Note:** このファイルは Zenn 公開用の下書きです。公開後は README のリンクを Zenn URL に差し替えてください。

--- a/hmscalc/__main__.py
+++ b/hmscalc/__main__.py
@@ -1,0 +1,5 @@
+"""Allow running hmscalc as ``python -m hmscalc``."""
+
+from hmscalc.cli import main
+
+raise SystemExit(main())

--- a/hmscalc/cli.py
+++ b/hmscalc/cli.py
@@ -1,0 +1,62 @@
+"""Command-line interface for hmscalc."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from typing import Sequence
+
+from hmscalc.hms_time import HMSTime
+
+
+def _parse_times(values: Sequence[str]) -> list[HMSTime]:
+    return [HMSTime(value) for value in values]
+
+
+def _subtract(times: list[HMSTime]) -> HMSTime:
+    if len(times) < 2:
+        raise ValueError("sub requires at least two time values")
+    result = times[0]
+    for other in times[1:]:
+        result = result - other
+    return result
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Run the hmscalc CLI and return an exit code."""
+    parser = argparse.ArgumentParser(
+        prog="hmscalc",
+        description="Add, subtract, and aggregate HH:MM[:SS] durations.",
+    )
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    add_parser = subparsers.add_parser("add", help="Add two or more durations")
+    add_parser.add_argument("times", nargs="+", metavar="TIME", help="HH:MM or HH:MM:SS")
+
+    sub_parser = subparsers.add_parser("sub", help="Subtract durations (first minus the rest)")
+    sub_parser.add_argument("times", nargs="+", metavar="TIME", help="HH:MM or HH:MM:SS")
+
+    sum_parser = subparsers.add_parser("sum", help="Sum two or more durations (alias for add)")
+    sum_parser.add_argument("times", nargs="+", metavar="TIME", help="HH:MM or HH:MM:SS")
+
+    args = parser.parse_args(argv)
+
+    try:
+        times = _parse_times(args.times)
+        if args.command == "sub":
+            result = _subtract(times)
+        else:
+            result = HMSTime.sum(times)
+    except (TypeError, ValueError) as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+    except Exception as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+
+    print(result)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/hmscalc/hms_time.py
+++ b/hmscalc/hms_time.py
@@ -169,7 +169,13 @@ class HMSTime:
         -------
             HMSTime: The corresponding HMSTime object.
 
+        Raises:
+        ------
+            TypeError: If ``total_seconds`` is not an ``int`` (``bool`` is rejected).
+
         """
+        if isinstance(total_seconds, bool) or not isinstance(total_seconds, int):
+            raise TypeError("total_seconds must be an int")
         instance = cls.__new__(cls)
         instance.total_seconds = total_seconds
         return instance

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "hmscalc"
-version = "0.5.0"
+version = "0.6.0"
 description = "Add and subtract HH:MM[:SS] time strings in Python — durations, aggregation, and timedelta integration."
 authors = ["M0209 <masanorimurakoshi0209@gmail.com>"]
 license = "MIT"
@@ -30,6 +30,9 @@ Changelog = "https://github.com/masanori0209/hmscalc/blob/main/CHANGELOG.md"
 
 [tool.poetry.dependencies]
 python = "^3.9"
+
+[tool.poetry.scripts]
+hmscalc = "hmscalc.cli:main"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^8.0.0"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -16,30 +16,35 @@ def _run_cli(*args: str) -> subprocess.CompletedProcess[str]:
 
 
 def test_cli_add() -> None:
+    """Test CLI add command sums durations."""
     result = _run_cli("add", "1:30", "2:15", "0:45")
     assert result.returncode == 0
     assert result.stdout.strip() == "4:30:00"
 
 
 def test_cli_sub() -> None:
+    """Test CLI sub command subtracts durations."""
     result = _run_cli("sub", "2:00", "0:45")
     assert result.returncode == 0
     assert result.stdout.strip() == "1:15:00"
 
 
 def test_cli_sum() -> None:
+    """Test CLI sum command matches add behavior."""
     result = _run_cli("sum", "1:00", "2:00", "3:00")
     assert result.returncode == 0
     assert result.stdout.strip() == "6:00:00"
 
 
 def test_cli_invalid_format() -> None:
+    """Test CLI returns error on invalid time format."""
     result = _run_cli("add", "bad")
     assert result.returncode == 1
     assert "error:" in result.stderr
 
 
 def test_cli_sub_requires_two_values() -> None:
+    """Test CLI sub requires at least two time values."""
     result = _run_cli("sub", "1:00")
     assert result.returncode == 1
     assert "at least two" in result.stderr

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,45 @@
+"""Tests for the hmscalc CLI."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+
+
+def _run_cli(*args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, "-m", "hmscalc", *args],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def test_cli_add() -> None:
+    result = _run_cli("add", "1:30", "2:15", "0:45")
+    assert result.returncode == 0
+    assert result.stdout.strip() == "4:30:00"
+
+
+def test_cli_sub() -> None:
+    result = _run_cli("sub", "2:00", "0:45")
+    assert result.returncode == 0
+    assert result.stdout.strip() == "1:15:00"
+
+
+def test_cli_sum() -> None:
+    result = _run_cli("sum", "1:00", "2:00", "3:00")
+    assert result.returncode == 0
+    assert result.stdout.strip() == "6:00:00"
+
+
+def test_cli_invalid_format() -> None:
+    result = _run_cli("add", "bad")
+    assert result.returncode == 1
+    assert "error:" in result.stderr
+
+
+def test_cli_sub_requires_two_values() -> None:
+    result = _run_cli("sub", "1:00")
+    assert result.returncode == 1
+    assert "at least two" in result.stderr

--- a/tests/test_hms_time.py
+++ b/tests/test_hms_time.py
@@ -135,7 +135,7 @@ def test_from_seconds_type_error() -> None:
     with pytest.raises(TypeError, match="must be an int"):
         HMSTime.from_seconds("3600")  # type: ignore[arg-type]
     with pytest.raises(TypeError, match="must be an int"):
-        HMSTime.from_seconds(True)  # type: ignore[arg-type]
+        HMSTime.from_seconds(True)
 
 
 def test_from_timedelta() -> None:

--- a/tests/test_hms_time.py
+++ b/tests/test_hms_time.py
@@ -128,6 +128,16 @@ def test_from_seconds() -> None:
     assert t.to_seconds() == 3661
 
 
+def test_from_seconds_type_error() -> None:
+    """Test from_seconds rejects non-int input."""
+    with pytest.raises(TypeError, match="must be an int"):
+        HMSTime.from_seconds(3.14)  # type: ignore[arg-type]
+    with pytest.raises(TypeError, match="must be an int"):
+        HMSTime.from_seconds("3600")  # type: ignore[arg-type]
+    with pytest.raises(TypeError, match="must be an int"):
+        HMSTime.from_seconds(True)  # type: ignore[arg-type]
+
+
 def test_from_timedelta() -> None:
     """Test creating HMSTime from datetime.timedelta."""
     delta = datetime.timedelta(hours=1, minutes=30, seconds=15)


### PR DESCRIPTION
## Summary
- CLI: `hmscalc add` / `sub` / `sum` and `python -m hmscalc` (#23)
- `from_seconds()` TypeError for non-int (#25)
- Zenn tutorial draft in `docs/articles/work-time-tutorial.md` (#26 — publish to Zenn manually)

## Test plan
- [x] 43 tests pass (Docker matrix)
- [ ] CI green

Closes #23, #25

Made with [Cursor](https://cursor.com)