### PR TITLE
Release v0.7.0: ISO 8601 & format()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.7.0] - 2026-06-07
+
+### Added
+
+- `HMSTime.from_iso8601()` / `to_iso8601()` for ISO 8601 time durations (`PT…`)
+- `HMSTime.format()` with `HH:MM` and `HH:MM:SS`
+- Input policy document (`docs/INPUT_POLICY.md`) — strict mode for v1.0
+
+### Changed
+
+- README: ISO 8601, format(), and input policy links
+
 ## [0.6.0] - 2026-06-07
 
 ### Added
@@ -98,6 +110,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Negative duration support
 - Custom exceptions: `InvalidTimeFormatError`, `NotTimeStringError`
 
+[0.7.0]: https://github.com/masanori0209/hmscalc/compare/v0.6.0...v0.7.0
 [0.6.0]: https://github.com/masanori0209/hmscalc/compare/v0.5.0...v0.6.0
 [0.5.0]: https://github.com/masanori0209/hmscalc/compare/v0.4.0...v0.5.0
 [0.4.0]: https://github.com/masanori0209/hmscalc/compare/v0.3.1...v0.4.0

--- a/README.md
+++ b/README.md
@@ -134,6 +134,24 @@ delta = t.to_timedelta()
 restored = HMSTime.from_timedelta(delta)  # HMSTime("1:30:15")
 ```
 
+### ISO 8601 Duration
+
+```python
+t = HMSTime.from_iso8601("PT1H30M15S")
+print(t.to_iso8601())  # "PT1H30M15S"
+print(str(t))          # "1:30:15"
+```
+
+Time section only (`PT…`); date parts like `P1D` are not supported.
+
+### Custom Output Format
+
+```python
+t = HMSTime("1:30:15")
+t.format("HH:MM")     # "1:30"
+t.format("HH:MM:SS")  # "1:30:15" — same as str(t)
+```
+
 ### Error Handling
 
 ```python
@@ -176,6 +194,7 @@ Parse `HH:MM` or `HH:MM:SS`. Whitespace is trimmed. Hours may exceed 24 (duratio
 |--------|-------------|
 | `HMSTime.from_seconds(total_seconds: int)` | Build from integer seconds |
 | `HMSTime.from_timedelta(delta)` | Build from `datetime.timedelta` |
+| `HMSTime.from_iso8601(duration)` | Build from ISO 8601 `PT…` duration |
 | `HMSTime.sum(times)` | Sum iterable; empty → `"0:00:00"` |
 | `HMSTime.average(times)` | Mean, rounded to nearest second |
 | `HMSTime.min(times)` / `HMSTime.max(times)` | Min / max of iterable |
@@ -188,6 +207,8 @@ Parse `HH:MM` or `HH:MM:SS`. Whitespace is trimmed. Hours may exceed 24 (duratio
 | `to_seconds()` | Integer total seconds (signed) |
 | `to_minutes()` / `to_hours()` | Float conversion |
 | `to_timedelta()` | `datetime.timedelta` |
+| `to_iso8601()` | ISO 8601 `PT…` string |
+| `format(fmt)` | `"HH:MM"` or `"HH:MM:SS"` (`__str__` = `format("HH:MM:SS")`) |
 | `to_tuple()` | `(hh, mm, ss)` absolute components |
 | `to_dict()` | `{'hh', 'mm', 'ss', 'negative'}` |
 
@@ -213,6 +234,7 @@ from hmscalc import HMSTimeError, InvalidTimeFormatError, NotTimeStringError
 - Minutes and seconds: 0–59
 - Optional leading `-` for negative durations
 - Surrounding whitespace is ignored
+- Strict mode only: overflow minutes/seconds (e.g. `1:90:00`) are rejected — see [Input Policy](docs/INPUT_POLICY.md)
 
 ## Development
 

--- a/docs/INPUT_POLICY.md
+++ b/docs/INPUT_POLICY.md
@@ -1,0 +1,30 @@
+# Input Policy
+
+hmscalc v1.0 uses **strict parsing only**. This document records the decision for issue #29.
+
+## Strict mode (current and v1.0)
+
+| Rule | Behavior |
+|------|----------|
+| Formats | `HH:MM`, `HH:MM:SS`, ISO 8601 time durations (`PT…`) |
+| Minutes / seconds | Must be `0–59`; values like `1:90:00` raise `InvalidTimeFormatError` |
+| Hours | Unbounded (duration model, not clock time) |
+| Whitespace | Leading/trailing whitespace is trimmed |
+| Sign | Optional leading `-` (HMS) or `-PT…` (ISO 8601) |
+| Non-strings | `HMSTime(...)` requires `str`; use `from_seconds()` for integers |
+
+## Lenient mode (not planned for v1.0)
+
+Normalizing overflow (e.g. `"1:90:00"` → `"2:30:00"`) is **out of scope** for v1.0.
+If added later, it would be opt-in (e.g. a parameter or separate parser) to avoid breaking strict callers.
+
+## Rationale
+
+- Strict validation catches data entry errors early.
+- Normalization rules (carry minutes into hours, etc.) add ambiguity.
+- v0.9.0 API freeze treats strict parsing as stable behavior for v1.0.
+
+## Related
+
+- README [Input Rules](../README.md#input-rules)
+- ISO 8601: `HMSTime.from_iso8601()` / `to_iso8601()` (time section only; no `P1D` date part)

--- a/hmscalc/hms_time.py
+++ b/hmscalc/hms_time.py
@@ -8,6 +8,12 @@ from typing import Iterable
 
 from .exceptions import InvalidTimeFormatError, NotTimeStringError
 
+_ISO8601_DURATION_RE = re.compile(
+    r"^(-?)PT(?:(\d+(?:\.\d+)?)H)?(?:(\d+(?:\.\d+)?)M)?(?:(\d+(?:\.\d+)?)S)?$",
+    re.IGNORECASE,
+)
+_SUPPORTED_FORMATS = frozenset({"HH:MM", "HH:MM:SS"})
+
 
 class HMSTime:
     """Class to represent and manipulate time in hours, minutes, and seconds (HMS) format.
@@ -196,6 +202,55 @@ class HMSTime:
         return cls.from_seconds(int(delta.total_seconds()))
 
     @classmethod
+    def from_iso8601(cls, duration: str) -> "HMSTime":
+        """Create an HMSTime from an ISO 8601 duration time component (``PT…``).
+
+        Supports ``PT1H30M15S``, ``PT30M``, ``-PT1H``, etc. Date components (``P1D``)
+        are not supported.
+
+        Args:
+        ----
+            duration (str): ISO 8601 duration string with a time section.
+
+        Returns:
+        -------
+            HMSTime: The parsed duration.
+
+        Raises:
+        ------
+            NotTimeStringError: If input is not a string.
+            InvalidTimeFormatError: If the string is not a valid time-only ISO 8601 duration.
+
+        """
+        if not isinstance(duration, str):
+            raise NotTimeStringError(duration)
+
+        duration = duration.strip()
+        if not duration:
+            raise InvalidTimeFormatError(duration)
+
+        match = _ISO8601_DURATION_RE.fullmatch(duration)
+        if not match:
+            raise InvalidTimeFormatError(duration)
+
+        neg, hours, minutes, seconds = match.groups()
+        if hours is None and minutes is None and seconds is None:
+            raise InvalidTimeFormatError(duration)
+
+        total = 0.0
+        if hours is not None:
+            total += float(hours) * 3600
+        if minutes is not None:
+            total += float(minutes) * 60
+        if seconds is not None:
+            total += float(seconds)
+
+        total_seconds = round(total)
+        if neg:
+            total_seconds = -total_seconds
+        return cls.from_seconds(total_seconds)
+
+    @classmethod
     def sum(cls, times: Iterable["HMSTime"]) -> "HMSTime":
         """Sum multiple HMSTime objects and return a new HMSTime object.
 
@@ -324,6 +379,47 @@ class HMSTime:
 
         total = hh * 3600 + mm * 60 + ss
         return -total if neg else total
+
+    def format(self, fmt: str = "HH:MM:SS") -> str:
+        """Format this duration as a string.
+
+        ``HH:MM:SS`` matches :meth:`__str__`. ``HH:MM`` omits seconds.
+
+        Args:
+        ----
+            fmt (str): ``"HH:MM"`` or ``"HH:MM:SS"``.
+
+        Returns:
+        -------
+            str: Formatted duration.
+
+        Raises:
+        ------
+            ValueError: If ``fmt`` is not supported.
+
+        """
+        if fmt not in _SUPPORTED_FORMATS:
+            raise ValueError(f"Unsupported format: {fmt!r}. Use 'HH:MM' or 'HH:MM:SS'.")
+        if fmt == "HH:MM:SS":
+            return str(self)
+        hh, mm, _ = self.to_tuple()
+        sign = "-" if self.is_negative else ""
+        return f"{sign}{hh}:{mm:02}"
+
+    def to_iso8601(self) -> str:
+        """Return an ISO 8601 duration string (time component only, ``PT…``)."""
+        if self.total_seconds == 0:
+            return "PT0S"
+        sign = "-" if self.is_negative else ""
+        hh, mm, ss = self.to_tuple()
+        parts: list[str] = []
+        if hh:
+            parts.append(f"{hh}H")
+        if mm:
+            parts.append(f"{mm}M")
+        if ss or not parts:
+            parts.append(f"{ss}S")
+        return f"{sign}PT{''.join(parts)}"
 
     def to_seconds(self) -> int:
         """Return the total number of seconds represented by this HMSTime object."""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "hmscalc"
-version = "0.6.0"
+version = "0.7.0"
 description = "Add and subtract HH:MM[:SS] time strings in Python — durations, aggregation, and timedelta integration."
 authors = ["M0209 <masanorimurakoshi0209@gmail.com>"]
 license = "MIT"

--- a/tests/test_hms_time.py
+++ b/tests/test_hms_time.py
@@ -294,3 +294,42 @@ def test_hashable() -> None:
     assert len({a, b, a}) == 2
     d = {a: "one", b: "two"}
     assert d[a] == "one"
+
+
+def test_from_iso8601() -> None:
+    """Test parsing ISO 8601 time durations."""
+    assert str(HMSTime.from_iso8601("PT1H30M15S")) == "1:30:15"
+    assert str(HMSTime.from_iso8601("PT30M")) == "0:30:00"
+    assert str(HMSTime.from_iso8601("-PT1H")) == "-1:00:00"
+    assert HMSTime.from_iso8601("PT0S").to_seconds() == 0
+
+
+def test_to_iso8601_roundtrip() -> None:
+    """Test ISO 8601 output round-trips through from_iso8601."""
+    original = HMSTime("1:30:15")
+    iso = original.to_iso8601()
+    assert iso == "PT1H30M15S"
+    assert HMSTime.from_iso8601(iso) == original
+
+
+def test_iso8601_invalid() -> None:
+    """Test invalid ISO 8601 durations raise errors."""
+    with pytest.raises(InvalidTimeFormatError):
+        HMSTime.from_iso8601("P1D")
+    with pytest.raises(InvalidTimeFormatError):
+        HMSTime.from_iso8601("PT")
+
+
+def test_format() -> None:
+    """Test custom format output."""
+    t = HMSTime("1:30:15")
+    assert t.format("HH:MM:SS") == "1:30:15"
+    assert t.format("HH:MM") == "1:30"
+    assert str(t) == t.format("HH:MM:SS")
+    assert HMSTime("-1:00:00").format("HH:MM") == "-1:00"
+
+
+def test_format_invalid() -> None:
+    """Test unsupported format raises ValueError."""
+    with pytest.raises(ValueError, match="Unsupported format"):
+        HMSTime("1:00:00").format("signed")


### PR DESCRIPTION
## Summary
- ISO 8601: `from_iso8601()` / `to_iso8601()` (#27)
- `format("HH:MM" | "HH:MM:SS")` (#28)
- Strict input policy documented (#29)

Closes #27, #28, #29

Made with [Cursor](https://cursor.com)