### PR TITLE
Release v0.9.0: API freeze RC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.9.0] - 2026-06-07
+
+### Added
+
+- API stability policy (`docs/API_STABILITY.md`) — public API freeze before v1.0
+- Migration guide (`docs/MIGRATION.md`) for 0.x → 1.0 upgrades
+
+### Note
+
+This is the **release candidate** for v1.0.0. No breaking changes are planned before stable.
+
 ## [0.8.0] - 2026-06-07
 
 ### Added
@@ -122,6 +135,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Negative duration support
 - Custom exceptions: `InvalidTimeFormatError`, `NotTimeStringError`
 
+[0.9.0]: https://github.com/masanori0209/hmscalc/compare/v0.8.0...v0.9.0
 [0.8.0]: https://github.com/masanori0209/hmscalc/compare/v0.7.0...v0.8.0
 [0.7.0]: https://github.com/masanori0209/hmscalc/compare/v0.6.0...v0.7.0
 [0.6.0]: https://github.com/masanori0209/hmscalc/compare/v0.5.0...v0.6.0

--- a/README.md
+++ b/README.md
@@ -253,6 +253,8 @@ Docker matrix (Python 3.9–3.14): `docker build -t hmscalc . && docker run --rm
 - [Changelog](CHANGELOG.md)
 - [Contributing](CONTRIBUTING.md)
 - [Security policy](SECURITY.md)
+- [API stability policy](docs/API_STABILITY.md)
+- [Migration guide](docs/MIGRATION.md)
 - [Roadmap (v1.0.0)](https://github.com/masanori0209/hmscalc/issues/20)
 - [Zenn: 作業時間を HH:MM で足し算する（チュートリアル）](docs/articles/work-time-tutorial.md) — 公開用下書き
 - [Zenn: PyPI 公開の記事](https://zenn.dev/m2lab/articles/454a3a0dd27dc8)

--- a/docs/API_STABILITY.md
+++ b/docs/API_STABILITY.md
@@ -1,0 +1,60 @@
+# API Stability Policy
+
+hmscalc follows [Semantic Versioning 2.0](https://semver.org/) from **v1.0.0** onward.
+
+## Public API (frozen at v1.0.0)
+
+Symbols exported in `hmscalc.__all__`:
+
+| Symbol | Kind |
+|--------|------|
+| `HMSTime` | Class |
+| `HMSTimeError` | Exception |
+| `InvalidTimeFormatError` | Exception |
+| `NotTimeStringError` | Exception |
+
+### `HMSTime` public surface
+
+**Constructor:** `HMSTime(time_str: str)`
+
+**Class methods:** `from_seconds`, `from_timedelta`, `from_iso8601`, `sum`, `average`, `min`, `max`
+
+**Instance methods / properties:** `is_negative`, `format`, `to_seconds`, `to_minutes`, `to_hours`, `to_timedelta`, `to_iso8601`, `to_tuple`, `to_dict`
+
+**Operators:** `+`, `-`, `*`, `/`, comparisons, `hash`
+
+**CLI:** `hmscalc` console script (`add`, `sub`, `sum`)
+
+Names prefixed with `_` are **not** public.
+
+## SemVer commitments (v1.x)
+
+| Change type | Version bump |
+|-------------|--------------|
+| Breaking API change | **Major** (2.0.0) |
+| Backward-compatible feature | **Minor** (1.1.0) |
+| Bug fix, docs, internal | **Patch** (1.0.1) |
+
+## Deprecation policy
+
+1. Mark deprecated APIs with `warnings.warn(..., DeprecationWarning)` for at least one **minor** release.
+2. Document in CHANGELOG and MIGRATION.md.
+3. Remove only in the next **major** release.
+
+## v1.0.0 release checklist
+
+- [x] Public API documented (README, package docstring)
+- [x] Strict input policy decided ([INPUT_POLICY.md](INPUT_POLICY.md))
+- [x] Test coverage ≥95%
+- [x] Python 3.9–3.14 CI matrix
+- [x] SECURITY.md and contribution guides
+- [ ] RC feedback period (v0.9.0)
+- [ ] Stable classifier on PyPI
+
+## Non-goals for v1.0
+
+- Lenient overflow normalization (`1:90:00` → `2:30:00`)
+- ISO 8601 date components (`P1D`)
+- Optional dependencies beyond stdlib
+
+These may be considered post-1.0 with explicit opt-in APIs.

--- a/docs/MIGRATION.md
+++ b/docs/MIGRATION.md
@@ -1,0 +1,56 @@
+# Migration Guide
+
+## Upgrading to v1.0.0 from 0.x
+
+v1.0.0 is the first **stable** release. There are **no intentional breaking changes** from v0.9.0.
+
+### Import path
+
+Always import from the package root:
+
+```python
+from hmscalc import HMSTime, HMSTimeError, InvalidTimeFormatError, NotTimeStringError
+```
+
+This has been stable since v0.3.0.
+
+### Notable API additions since 0.1.0
+
+| Version | Change |
+|---------|--------|
+| 0.3.0 | Package root exports; exception types |
+| 0.4.0 | Scalar `*` `/`, `__hash__`, `from_timedelta`, whitespace trim |
+| 0.6.0 | CLI (`hmscalc add/sub/sum`), stricter `from_seconds()` |
+| 0.7.0 | `from_iso8601` / `to_iso8601`, `format()` |
+| 0.8.0 | Coverage and property tests (no API change) |
+
+### `to_dict()` shape
+
+Since v0.4.0, `to_dict()` includes a `negative` boolean key:
+
+```python
+{"hh": 1, "mm": 30, "ss": 15, "negative": False}
+```
+
+If you relied on pre-0.4.0 behavior without `negative`, update dict consumers accordingly.
+
+### Input validation
+
+Strict mode only: `mm` and `ss` must be 0–59. See [INPUT_POLICY.md](INPUT_POLICY.md).
+
+### CLI
+
+Available since v0.6.0:
+
+```bash
+pip install hmscalc
+hmscalc sum 1:00 2:00
+```
+
+## v0.x → v1.0.0 checklist
+
+1. Pin `hmscalc>=1.0.0,<2` in production.
+2. Replace any private imports (`hmscalc.hms_time._…`) with public API.
+3. Run your test suite; report issues via GitHub Security or Issues.
+
+See [API_STABILITY.md](API_STABILITY.md) for long-term SemVer policy.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "hmscalc"
-version = "0.8.0"
+version = "0.9.0"
 description = "Add and subtract HH:MM[:SS] time strings in Python — durations, aggregation, and timedelta integration."
 authors = ["M0209 <masanorimurakoshi0209@gmail.com>"]
 license = "MIT"


### PR DESCRIPTION
## Summary
- API stability policy (#33)
- Migration guide (#35)
- RC release for v1.0.0 (#36)

Closes #33, #35, #36

Made with [Cursor](https://cursor.com)