### PR TITLE
Release v1.0.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.6] - 2026-06-07
+
+### Changed
+
+- Dev dependency: pytest-cov 6.3.0 → 7.1.0
+- CLI tests: in-process coverage for pytest-cov 7 compatibility
+
 ## [1.0.5] - 2026-06-07
 
 ### Changed
@@ -177,6 +184,7 @@ This is the **release candidate** for v1.0.0. No breaking changes are planned be
 - Negative duration support
 - Custom exceptions: `InvalidTimeFormatError`, `NotTimeStringError`
 
+[1.0.6]: https://github.com/masanori0209/hmscalc/compare/v1.0.5...v1.0.6
 [1.0.5]: https://github.com/masanori0209/hmscalc/compare/v1.0.4...v1.0.5
 [1.0.4]: https://github.com/masanori0209/hmscalc/compare/v1.0.3...v1.0.4
 [1.0.3]: https://github.com/masanori0209/hmscalc/compare/v1.0.2...v1.0.3

--- a/poetry.lock
+++ b/poetry.lock
@@ -824,23 +824,23 @@ dev = ["argcomplete", "attrs (>=19.2)", "hypothesis (>=3.56)", "mock", "requests
 
 [[package]]
 name = "pytest-cov"
-version = "6.3.0"
+version = "7.1.0"
 description = "Pytest plugin for measuring coverage."
 optional = false
 python-versions = ">=3.9"
 groups = ["dev"]
 files = [
-    {file = "pytest_cov-6.3.0-py3-none-any.whl", hash = "sha256:440db28156d2468cafc0415b4f8e50856a0d11faefa38f30906048fe490f1749"},
-    {file = "pytest_cov-6.3.0.tar.gz", hash = "sha256:35c580e7800f87ce892e687461166e1ac2bcb8fb9e13aea79032518d6e503ff2"},
+    {file = "pytest_cov-7.1.0-py3-none-any.whl", hash = "sha256:a0461110b7865f9a271aa1b51e516c9a95de9d696734a2f71e3e78f46e1d4678"},
+    {file = "pytest_cov-7.1.0.tar.gz", hash = "sha256:30674f2b5f6351aa09702a9c8c364f6a01c27aae0c1366ae8016160d1efc56b2"},
 ]
 
 [package.dependencies]
-coverage = {version = ">=7.5", extras = ["toml"]}
+coverage = {version = ">=7.10.6", extras = ["toml"]}
 pluggy = ">=1.2"
-pytest = ">=6.2.5"
+pytest = ">=7"
 
 [package.extras]
-testing = ["fields", "hunter", "process-tests", "pytest-xdist", "virtualenv"]
+testing = ["process-tests", "pytest-xdist", "virtualenv"]
 
 [[package]]
 name = "pytokens"
@@ -1032,4 +1032,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.9"
-content-hash = "bf36dda023c1e4727e3ea2f6c7e4277523febbdace42d6f254ff2dc480c2d746"
+content-hash = "0836c17f09833a27a1c0fb77ddd1eb3d4f0f9a4969ecdc82b4904ed3d361abd8"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "hmscalc"
-version = "1.0.5"
+version = "1.0.6"
 description = "Add and subtract HH:MM[:SS] time strings in Python — durations, aggregation, and timedelta integration."
 authors = ["M0209 <masanorimurakoshi0209@gmail.com>"]
 license = "MIT"
@@ -36,7 +36,7 @@ hmscalc = "hmscalc.cli:main"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^8.0.0"
-pytest-cov = "^6.0.0"
+pytest-cov = "^7.1.0"
 black = ">=24,<26"
 isort = "^6.1.0"
 mypy = "^1.9.0"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -5,6 +5,10 @@ from __future__ import annotations
 import subprocess
 import sys
 
+import pytest
+
+from hmscalc.cli import main
+
 
 def _run_cli(*args: str) -> subprocess.CompletedProcess[str]:
     return subprocess.run(
@@ -48,3 +52,21 @@ def test_cli_sub_requires_two_values() -> None:
     result = _run_cli("sub", "1:00")
     assert result.returncode == 1
     assert "at least two" in result.stderr
+
+
+def test_cli_main_direct_add(capsys: pytest.CaptureFixture[str]) -> None:
+    """Test in-process CLI add for coverage under pytest-cov 7."""
+    assert main(["add", "1:00", "2:00"]) == 0
+    assert capsys.readouterr().out.strip() == "3:00:00"
+
+
+def test_cli_main_direct_sub(capsys: pytest.CaptureFixture[str]) -> None:
+    """Test in-process CLI sub for coverage under pytest-cov 7."""
+    assert main(["sub", "2:00", "0:30"]) == 0
+    assert capsys.readouterr().out.strip() == "1:30:00"
+
+
+def test_cli_main_direct_invalid(capsys: pytest.CaptureFixture[str]) -> None:
+    """Test in-process CLI error handling."""
+    assert main(["add", "invalid"]) == 1
+    assert "error:" in capsys.readouterr().err


### PR DESCRIPTION
Bump pytest-cov 7.1.0 with in-process CLI tests (replaces Dependabot #47).

Made with [Cursor](https://cursor.com)