### PR TITLE
docs: README/CONTRIBUTING sync with v1.0.6

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,7 +19,7 @@ Typical flow: branch from `main` → PR → CI pass → merge → tag `vX.Y.Z` o
 ```bash
 poetry install
 poetry run pytest
-poetry run pytest --cov=hmscalc --cov-report=term-missing
+poetry run pytest --cov=hmscalc --cov-report=term-missing --cov-fail-under=95
 poetry run ruff check hmscalc tests
 poetry run black --check hmscalc tests
 poetry run isort --check-only hmscalc tests

--- a/README.md
+++ b/README.md
@@ -8,12 +8,13 @@
 
 Add and subtract **HH:MM** / **HH:MM:SS** time strings in Python — no manual conversion to seconds required.
 
-**v1.0.0** is the first stable release with [SemVer API guarantees](docs/API_STABILITY.md).
+**Stable since v1.0.0** (latest: **v1.0.6**) — [SemVer API guarantees](docs/API_STABILITY.md) · [Changelog](CHANGELOG.md)
 
 ## Quick Start
 
 ```bash
 pip install hmscalc
+# or pin stable: pip install "hmscalc>=1.0,<2"
 ```
 
 ```python
@@ -46,6 +47,7 @@ print(a / 2)   # "0:45:07"
 - Input whitespace trimming (`" 1:30:15 "`)
 - Type hints with `py.typed` marker
 - Python **3.9** through **3.14**
+- ISO 8601 duration (`from_iso8601` / `to_iso8601`) and custom `format()`
 - CLI: `hmscalc add` / `sub` / `sum` from the terminal
 
 ## CLI
@@ -245,7 +247,7 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for branching, CI, and release process.
 
 ```bash
 poetry install
-poetry run pytest --cov=hmscalc
+poetry run pytest --cov=hmscalc --cov-fail-under=95
 ```
 
 Docker matrix (Python 3.9–3.14): `docker build -t hmscalc . && docker run --rm hmscalc ./runtests.sh`
@@ -258,7 +260,6 @@ Docker matrix (Python 3.9–3.14): `docker build -t hmscalc . && docker run --rm
 - [Security policy](SECURITY.md)
 - [API stability policy](docs/API_STABILITY.md)
 - [Migration guide](docs/MIGRATION.md)
-- [Roadmap (v1.0.0)](https://github.com/masanori0209/hmscalc/issues/20)
 - [Zenn: v1.0.0 Stable リリース（下書き）](docs/articles/v1-stable-release.md)
 - [Zenn: 作業時間を HH:MM で足し算する（チュートリアル）](docs/articles/work-time-tutorial.md) — 公開用下書き
 - [Zenn: PyPI 公開の記事](https://zenn.dev/m2lab/articles/454a3a0dd27dc8)

--- a/docs/MIGRATION.md
+++ b/docs/MIGRATION.md
@@ -1,8 +1,8 @@
 # Migration Guide
 
-## Upgrading to v1.0.0 from 0.x
+## Upgrading to v1.0.x from 0.x
 
-v1.0.0 is the first **stable** release. There are **no intentional breaking changes** from v0.9.0.
+v1.0.0 is the first **stable** release (current: **1.0.6**). Patch releases 1.0.1–1.0.6 are dev/CI dependency updates only — no public API changes.
 
 ### Import path
 


### PR DESCRIPTION
## Summary
- README: latest stable v1.0.6, ISO8601 in Features, coverage ≥95%
- CONTRIBUTING: match CI coverage flag
- MIGRATION: note 1.0.1–1.0.6 patch scope
- Remove link to closed roadmap #20

No code or API changes.

Made with [Cursor](https://cursor.com)