### PR TITLE
Release v1.0.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.7] - 2026-06-15
+
+### Changed
+
+- README / CONTRIBUTING / MIGRATION synced with v1.0.6 state (coverage threshold, feature list)
+
 ## [1.0.6] - 2026-06-07
 
 ### Changed
@@ -184,6 +190,7 @@ This is the **release candidate** for v1.0.0. No breaking changes are planned be
 - Negative duration support
 - Custom exceptions: `InvalidTimeFormatError`, `NotTimeStringError`
 
+[1.0.7]: https://github.com/masanori0209/hmscalc/compare/v1.0.6...v1.0.7
 [1.0.6]: https://github.com/masanori0209/hmscalc/compare/v1.0.5...v1.0.6
 [1.0.5]: https://github.com/masanori0209/hmscalc/compare/v1.0.4...v1.0.5
 [1.0.4]: https://github.com/masanori0209/hmscalc/compare/v1.0.3...v1.0.4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "hmscalc"
-version = "1.0.6"
+version = "1.0.7"
 description = "Add and subtract HH:MM[:SS] time strings in Python — durations, aggregation, and timedelta integration."
 authors = ["M0209 <masanorimurakoshi0209@gmail.com>"]
 license = "MIT"


### PR DESCRIPTION
Docs-only release: README/CONTRIBUTING/MIGRATION alignment.

Made with [Cursor](https://cursor.com)